### PR TITLE
MAJOR: Add sorting and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,60 +407,74 @@ const query = new QueryBuilder()
 
 ```javascript
 builder.func(
-  field?: string, // or Type of function
+  field?: string|Object, // or Type of function
   value?: string|Object
 )
 ```
 
 ###### Examples
 
-Simple sort
+Field value factor function
 ```javascript
 const query = new QueryBuilder()
   .query( ... )
-  .sort('age', 'desc')
-  .build();
+  .func('field_value_factor', {
+    field: 'number_of_something',
+    modifier: 'ln2p',
+    factor: 1
+  })
+  .buildFunctionScore();
   
 //- Generates the following query
 {
   from: 0,
   size: 15,
-  query: { ... },
-  sort: [
-    { age: 'desc' }
-  ]
+  query: {
+    function_score: {
+      query: { ... },
+      functions: [{
+        field_value_factor: {
+          field: 'number_of_something',
+          modifier: 'ln2p',
+          factor: 1
+        }
+      }]
+    }
+  }
 }
 ```
 
-Geo distance sort
+Filter function
 ```javascript
 const query = new QueryBuilder()
   .query( ... )
-  .sort('_geo_distance', {
-    coordinates: [ -70, 40 ],
-    distance_type: 'arc',
-    order: 'asc',
-    unit: 'mi',
-    mode: 'min'
+  .func({
+    weight: 100,
+    filter: {
+      match: {
+        state: 'Colorado'
+      }
+    }
   })
-  .build();
+  .buildFunctionScore();
   
 //- Generates the following query
 {
   from: 0,
   size: 15,
-  query: { ... },
-  sort: [
-    {
-      _geo_distance: {
-        coordinates: [ -70, 40 ],
-        distance_type: 'arc',
-        order: 'asc',
-        unit: 'mi',
-        mode: 'min'
-      }
+  query: {
+    function_score: {
+      query: { ... },
+      functions: [{
+        weight: 100,
+        filter: {
+          match: {
+            state: 'Colorado'
+          }
+        }
+      }]
     }
-  ]
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -232,15 +232,19 @@ builder.aggs(
 Simple Aggregation
 ```javascript
 const query = new QueryBuilder()
+  .query('match_all')
   .raw('explain', true)
   .aggs('avg', 'count')
-  .buildAggregation();
+  .build();
 
 //- Generates the following query
 {
   from: 0,
   size: 15,
   explain: true,
+  query: {
+    match_all: {}
+  },
   aggs: {
     count: {
       avg: {
@@ -254,6 +258,7 @@ const query = new QueryBuilder()
 Multiple Aggregations
 ```javascript
 const query = new QueryBuilder()
+  .query('match_all')
   .aggs('geo_distance', 'location', {
     origin: '52.3760, 4.894',
     unit: 'km',
@@ -265,12 +270,15 @@ const query = new QueryBuilder()
   })
   .aggs('max', 'price')
   .aggs('sum', 'sales')
-  .buildAggregation()
+  .build()
 
 //- Generates the following query
 {
   from: 0,
   size: 15,
+  query: {
+    match_all: {}
+  },
   aggs: {
     location: {
       geo_distance: {
@@ -302,15 +310,19 @@ const query = new QueryBuilder()
 Nested Aggregations
 ```javascript
 const query = new QueryBuilder()
+  .query('match_all')
   .aggs('nested', { path: 'locations' }, builder => builder
     .aggs('terms', 'locations.city')
   )
-  .buildAggregation()
+  .build()
 
 //- Generates the following query
 {
   from: 0,
   size: 15,
+  query: {
+    match_all: {}
+  },
   aggs: {
     locations: {
       nested: {
@@ -328,91 +340,84 @@ const query = new QueryBuilder()
 }
 ```
 
-##### `filteredAggs`
-> Add aggregations to your query that will be filtered based on the current query. These will also filter out any filters that would apply to the aggregation field so that agg counters (facet counters) would be correct. See [this article](https://blog.madewithlove.be/post/faceted-search-using-elasticsearch/) for a good explanation
+##### `sort`
+> Add sorting options. This method essentially just takes a key and a value for an object.
 
 ```javascript
-builder.filteredAggs(
-  options: {
-    field: string,
-    size: number,
-    include: string, 
-    exclude: string,
-    // Can include any other valid properties to associate with an aggregation 
-  }
+builder.sort(
+  // or Type of sort, could be _geo_distance
+  field?: string,
+  value?: string|Object
 )
 ```
 
 ###### Examples
-> See  [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
 
-Adding filtered aggreations to a boolean query
+Simple sort
 ```javascript
 const query = new QueryBuilder()
-  .must('match', 'grade', '4th')
-  .must('match', 'gender', 'female')
-  .filteredAggs({ field: 'grade', size: 12, exclude: 'Kindergarten' })
+  .query( ... )
+  .sort('age', 'desc')
   .build();
-
+  
 //- Generates the following query
 {
   from: 0,
   size: 15,
-  query: {
-    bool: {
-      must: [
-        { match: { grade: '4th' }},
-        { match: { gender: 'female' }}
-      ]
-    }
-  },
-  aggs: {
-    all: {
-      global: {},
-      aggs: {
-        grade: {
-          aggs: {
-            grade: {
-              terms: {
-                field: 'grade',
-                size: 12,
-                exclude: 'Kindergarten'
-              }
-            }
-          },
-          filter: {
-            bool: {
-              must: [
-                { match: { gender: 'female' }}
-              ]
-            }
-          }
-        }
-      }
-    }
-  }
+  query: { ... },
+  sort: [
+    { age: 'desc' }
+  ]
 }
 ```
+
+Geo distance sort
+```javascript
+const query = new QueryBuilder()
+  .query( ... )
+  .sort('_geo_distance', {
+    coordinates: [ -70, 40 ],
+    distance_type: 'arc',
+    order: 'asc',
+    unit: 'mi',
+    mode: 'min'
+  })
+  .build();
+  
+//- Generates the following query
+{
+  from: 0,
+  size: 15,
+  query: { ... },
+  sort: [
+    {
+      _geo_distance: {
+        coordinates: [ -70, 40 ],
+        distance_type: 'arc',
+        order: 'asc',
+        unit: 'mi',
+        mode: 'min'
+      }
+    }
+  ]
+}
+```
+
 
 ### Build Functions
 
 ##### `build`
-> Build your basic query. This includes parameters set using `query`, `must`, `should`, `filter`, `must_not`, `filteredAggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
+> Build your basic query. This includes parameters set using `query`, `must`, `should`, `filter`, `must_not`, `aggs`, `filteredAggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
 
 ```javascript
 builder.build(
   options?: {
     // Name for your top level aggregations, default is 'all'
-    name?: string
+    name?: string,
+    // Should we add filters to our aggregations, better for accurate facet counts
+    filterAggs?: boolean
   }
 ): Object
-```
-
-##### `buildAggregation`
-> Build your basic query. This includes parameters set using `aggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
-
-```javascript
-builder.buildAggregation(): Object
 ```
 
 ##### `buildDisMax`

--- a/README.md
+++ b/README.md
@@ -407,14 +407,14 @@ const query = new QueryBuilder()
 ### Build Functions
 
 ##### `build`
-> Build your basic query. This includes parameters set using `query`, `must`, `should`, `filter`, `must_not`, `aggs`, `filteredAggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
+> Build your basic query. This includes parameters set using `query`, `must`, `should`, `filter`, `must_not`, `aggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
 
 ```javascript
 builder.build(
   options?: {
-    // Name for your top level aggregations, default is 'all'
+    // Name for your filtered aggregations, default is 'all'
     name?: string,
-    // Should we add filters to our aggregations, better for accurate facet counts
+    // Add filters to your aggregations, better for accurate facet counts
     filterAggs?: boolean
   }
 ): Object

--- a/README.md
+++ b/README.md
@@ -345,8 +345,7 @@ const query = new QueryBuilder()
 
 ```javascript
 builder.sort(
-  // or Type of sort, could be _geo_distance
-  field?: string,
+  field?: string, // or Type of sort, could be something like _geo_distance
   value?: string|Object
 )
 ```
@@ -403,6 +402,67 @@ const query = new QueryBuilder()
 }
 ```
 
+##### `func`
+> Add functions to be used in function_score queries. This method essentially just takes a key and a value for an object and is only used when calling `buildFunctionScore`.
+
+```javascript
+builder.func(
+  field?: string, // or Type of function
+  value?: string|Object
+)
+```
+
+###### Examples
+
+Simple sort
+```javascript
+const query = new QueryBuilder()
+  .query( ... )
+  .sort('age', 'desc')
+  .build();
+  
+//- Generates the following query
+{
+  from: 0,
+  size: 15,
+  query: { ... },
+  sort: [
+    { age: 'desc' }
+  ]
+}
+```
+
+Geo distance sort
+```javascript
+const query = new QueryBuilder()
+  .query( ... )
+  .sort('_geo_distance', {
+    coordinates: [ -70, 40 ],
+    distance_type: 'arc',
+    order: 'asc',
+    unit: 'mi',
+    mode: 'min'
+  })
+  .build();
+  
+//- Generates the following query
+{
+  from: 0,
+  size: 15,
+  query: { ... },
+  sort: [
+    {
+      _geo_distance: {
+        coordinates: [ -70, 40 ],
+        distance_type: 'arc',
+        order: 'asc',
+        unit: 'mi',
+        mode: 'min'
+      }
+    }
+  ]
+}
+```
 
 ### Build Functions
 
@@ -511,6 +571,20 @@ const query = new QueryBuilder()
     }
   }
 }
+```
+
+##### `buildFunctionScore`
+> Build your basic query. This includes parameters set using `query`, `must`, `should`, `filter`, `must_not`, `aggs`, `from`, `size`, and `raw`. See [`__tests__`](https://github.com/Asymmetrik/elastic-querybuilder/blob/master/__tests__) for more examples.
+
+```javascript
+builder.buildFunctionScore(
+  options?: {
+    // Name for your filtered aggregations, default is 'all'
+    name?: string,
+    // Add filters to your aggregations, better for accurate facet counts
+    filterAggs?: boolean
+  }
+): Object
 ```
 
 ## Contributing

--- a/__tests__/QueryBuilder.aggregations.test.js
+++ b/__tests__/QueryBuilder.aggregations.test.js
@@ -4,9 +4,10 @@ describe('QueryBuilder - Build Aggregations', () => {
 
 	test('should build a simple aggregation', () => {
 		const query = new QueryBuilder()
+			.query('match_all')
 			.raw('explain', true)
 			.aggs('avg', 'count')
-			.buildAggregation();
+			.build();
 
 		expect(query).toEqual({
 			from: 0,
@@ -27,11 +28,12 @@ describe('QueryBuilder - Build Aggregations', () => {
 
 	test('should build a simple aggregation with an object for the value arg', () => {
 		const query = new QueryBuilder()
+			.query('match_all')
 			.aggs('terms', {
 				field: 'games',
 				exclude: 'Call.*'
 			})
-			.buildAggregation();
+			.build();
 
 		// The below method is preferred, this is available since we need this method
 		// for nested aggregations
@@ -54,8 +56,9 @@ describe('QueryBuilder - Build Aggregations', () => {
 
 	test('should build a simple aggregation with some extra options', () => {
 		const query = new QueryBuilder()
+			.query('match_all')
 			.aggs('terms', 'games', { exclude: 'Call.*' })
-			.buildAggregation();
+			.build();
 
 		// Same as above except a little more obvious
 		expect(query).toEqual({
@@ -77,6 +80,7 @@ describe('QueryBuilder - Build Aggregations', () => {
 
 	test('should be able to handle multiple aggregations in one query', () => {
 		const query = new QueryBuilder()
+			.query('match_all')
 			.aggs('geo_distance', 'location', {
 				origin: '52.3760, 4.894',
 				unit: 'km',
@@ -88,7 +92,7 @@ describe('QueryBuilder - Build Aggregations', () => {
 			})
 			.aggs('max', 'price')
 			.aggs('sum', 'sales')
-			.buildAggregation();
+			.build();
 
 		expect(query).toEqual({
 			from: 0,
@@ -125,10 +129,11 @@ describe('QueryBuilder - Build Aggregations', () => {
 
 	test('should build a nested type aggregation', () => {
 		const query = new QueryBuilder()
+			.query('match_all')
 			.aggs('nested', { path: 'locations' }, builder => builder
 				.aggs('terms', 'locations.city')
 			)
-			.buildAggregation();
+			.build();
 
 		expect(query).toEqual({
 			from: 0,
@@ -157,7 +162,7 @@ describe('QueryBuilder - Build Aggregations', () => {
 		const query = new QueryBuilder()
 			.must('match', 'school', 'South Park Elementary')
 			.aggs('avg', 'count')
-			.buildAggregation();
+			.build();
 
 		expect(query).toEqual({
 			from: 0,
@@ -183,8 +188,8 @@ describe('QueryBuilder - Build Aggregations', () => {
 			.must('match', 'grade', '4th')
 			.must('match', 'enemy', 'Cartman')
 			.should('match', 'gender', 'female')
-			.filteredAggs({ field: 'grade', size: 12 })
-			.build();
+			.aggs('terms', 'grade', { size: 12 })
+			.build({ filterAggs: true });
 
 		expect(query).toEqual({
 			from: 0,

--- a/__tests__/QueryBuilder.test.js
+++ b/__tests__/QueryBuilder.test.js
@@ -14,7 +14,16 @@ const mocks = {
 	multi_match: {
 		query: 'The Coon',
 		fields: ['superhero', 'name', 'alias']
-	}
+	},
+	functions: [
+		{
+			field_value_factor: {
+				field: 'number_of_detentions',
+				factor: 1,
+				modifier: 'ln2p'
+			}
+		}
+	]
 };
 
 describe('QueryBuilder', () => {
@@ -122,6 +131,71 @@ describe('QueryBuilder', () => {
 						should: {
 							match_phrase: { most_common_question: 'Who is Mysterion?' }
 						}
+					}
+				}
+			});
+		});
+
+		test('should build a simple query with sorting options', () => {
+			const query = new QueryBuilder()
+				.must('match', 'grade', '4th')
+				.sort('gpa', { order: 'desc', mode: 'avg' })
+				.build();
+
+			expect(query).toEqual({
+				from: 0,
+				size: 15,
+				query: {
+					match: {
+						grade: '4th'
+					}
+				},
+				sort: [{
+					gpa: {
+						order: 'desc',
+						mode: 'avg'
+					}
+				}]
+			});
+		});
+
+		test('should build a function score query with filters, functions, and settings', () => {
+			const query = new QueryBuilder()
+				.raw('query.function_score.functions', mocks.functions)
+				.raw('query.function_score.score_mode', 'sum')
+				.raw('query.function_score.boost_mode', 'sum')
+				.query('function_score', builder => builder
+					.query('dis_max', {
+						tie_breaker: 1,
+						queries: mocks.dis_max_queries
+					})
+				)
+				.build();
+
+			expect(query).toEqual({
+				from: 0,
+				size: 15,
+				query: {
+					function_score: {
+						query: {
+							dis_max: {
+								tie_breaker: 1,
+								queries: [
+									{ term: { age: 31 }},
+									{ term: { age: 32 }},
+									{ term: { age: 33 }}
+								]
+							}
+						},
+						functions: [{
+							field_value_factor: {
+								field: 'number_of_detentions',
+								factor: 1,
+								modifier: 'ln2p'
+							}
+						}],
+						score_mode: 'sum',
+						boost_mode: 'sum'
 					}
 				}
 			});
@@ -330,6 +404,47 @@ describe('QueryBuilder', () => {
 						]
 					}
 				}
+			});
+		});
+
+		test('should build simple dis_max with sort options', () => {
+			const query = new QueryBuilder()
+				.sort('_geo_distance', {
+					coordinates: [ -70, 40 ],
+					distance_type: 'arc',
+					order: 'asc',
+					unit: 'mi',
+					mode: 'min'
+				})
+				.buildMultiMatch({
+					query: mocks.multi_match.query,
+					fields: mocks.multi_match.fields,
+					type: 'best_fields',
+					tie_breaker: 0.3,
+					minimum_should_match: '30%'
+				});
+
+			expect(query).toEqual({
+				from: 0,
+				size: 15,
+				query: {
+					multi_match: {
+						query: 'The Coon',
+						fields: ['superhero', 'name', 'alias'],
+						type: 'best_fields',
+						tie_breaker: 0.3,
+						minimum_should_match: '30%'
+					}
+				},
+				sort: [{
+					_geo_distance: {
+						coordinates: [ -70, 40 ],
+						distance_type: 'arc',
+						order: 'asc',
+						unit: 'mi',
+						mode: 'min'
+					}
+				}]
 			});
 		});
 

--- a/__tests__/QueryBuilder.test.js
+++ b/__tests__/QueryBuilder.test.js
@@ -407,7 +407,7 @@ describe('QueryBuilder', () => {
 			});
 		});
 
-		test('should build simple dis_max with sort options', () => {
+		test('should build simple multi_match with sort options', () => {
 			const query = new QueryBuilder()
 				.sort('_geo_distance', {
 					coordinates: [ -70, 40 ],

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -41,12 +41,14 @@ const mocks = {
 			field: 'alias'
 		}
 	],
-	aggregations: [
-		{
-			field: 'grade',
-			size: 20
+	aggregations: {
+		grade: {
+			terms: {
+				field: 'grade',
+				size: 20
+			}
 		}
-	]
+	}
 };
 
 describe('utils', () => {
@@ -228,33 +230,21 @@ describe('utils', () => {
 			expect(perform_check).toThrowError(ERRORS.NOT_AN_ARRAY);
 		});
 
-		test('should throw an error if aggregations are not an array', () => {
-			function perform_check () {
-				utils.prepareFilteredAggregation({
-					aggregations: {},
-					descriptors: []
-				});
-			}
-
-			expect(perform_check).toThrowError(ERRORS.NOT_AN_ARRAY);
-		});
-
 		test('should throw an error if descriptors are not an array', () => {
 			function perform_check () {
-				utils.prepareFilteredAggregation({
-					aggregations: [],
-					descriptors: {}
-				});
+				const aggs = {};
+				const descriptors = {};
+				utils.prepareFilteredAggregation(aggs, descriptors);
 			}
 
 			expect(perform_check).toThrowError(ERRORS.NOT_AN_ARRAY);
 		});
 
 		test('should create an aggregation with the default `all` name if no name is provided', () => {
-			const result = utils.prepareFilteredAggregation({
-				aggregations: mocks.aggregations,
-				descriptors: mocks.single_should_descriptor
-			});
+			const result = utils.prepareFilteredAggregation(
+				mocks.aggregations,
+				mocks.single_should_descriptor
+			);
 
 			expect(result).toEqual({
 				all: {
@@ -278,11 +268,11 @@ describe('utils', () => {
 		});
 
 		test('should create a valid aggregation object with the correct filters applied', () => {
-			const result = utils.prepareFilteredAggregation({
-				aggregations: mocks.aggregations,
-				descriptors: mocks.mixed_descriptors,
-				name: 'south_park_aggs'
-			});
+			const result = utils.prepareFilteredAggregation(
+				mocks.aggregations,
+				mocks.mixed_descriptors,
+				'south_park_aggs'
+			);
 
 			expect(result).toEqual({
 				south_park_aggs: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/elastic-querybuilder",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A query builder for Elasticsearch.",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/elastic-querybuilder.git",

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -119,7 +119,7 @@ class BaseBuilder {
 
 	/**
 	* @description Add functions for function_score queries
-	* @param {string|Object} field - Field/type for sorting
+	* @param {string|Object} field - Field/type for functions
 	* @param {string|Object} value - Value of the Field/Type
 	* @return {BaseBuilder} this
 	*/
@@ -182,7 +182,7 @@ class BaseBuilder {
 	}
 
 	/**
-	* @description Return our sorting options
+	* @description Return our functions
 	* @return {Array<Object>} - Array of functions
 	*/
 	getFuncs () {

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -17,10 +17,8 @@ class BaseBuilder {
 		* We do this so it is trivial to filter them for filtered aggregations at a later point.
 		*/
 		this._queries = [];
-		this._filteredAggs = [];
-		/**
-		* Let's build this one up as we go instead of pushing descriptors in it
-		*/
+
+		this._sorts = [];
 		this._aggs = {};
 	}
 
@@ -108,17 +106,13 @@ class BaseBuilder {
 	}
 
 	/**
-	* @description Add a field that will be used to generate filtered aggregations
-	* based on your current boolean filters. Use this for accurate facet counts.
-	* @param {Object} agg - Options for the aggregation
-	* @param {number} agg.size - Maximum number of aggregations to include in the response
-	* @param {string} agg.field - Field name to aggregate on
-	* @param {string} agg.include - pattern to include in the buckets list
-	* @param {string} agg.exclude - pattern to exclude in the buckets list
+	* @description Add options for sorting
+	* @param {string} field - Field/type for sorting
+	* @param {string|Object} value - Value of the Field/Type
 	* @return {BaseBuilder} this
 	*/
-	filteredAggs (agg) {
-		this._filteredAggs.push(agg);
+	sort (field, value) {
+		this._sorts.push({ [field]: value });
 		return this;
 	}
 
@@ -128,6 +122,22 @@ class BaseBuilder {
 	*/
 	hasQuery () {
 		return this._queries.length;
+	}
+
+	/**
+	* @description Do we have non-filtered aggregations to build
+	* @return {boolean}
+	*/
+	hasAggs () {
+		return Object.getOwnPropertyNames(this._aggs).length;
+	}
+
+	/**
+	* @description Do we have any sorting operations to apply
+	* @return {boolean}
+	*/
+	hasSort () {
+		return this._sorts.length;
 	}
 
 	/**
@@ -144,8 +154,16 @@ class BaseBuilder {
 	* @description Return our aggs, these were built up as we go
 	* @return {Object} - ES Aggregations
 	*/
-	buildAggs () {
+	getAggs () {
 		return this._aggs;
+	}
+
+	/**
+	* @description Return our sorting options
+	* @return {Array<Object>} - Array of sort objects
+	*/
+	getSorts () {
+		return this._sorts;
 	}
 
 }

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -18,6 +18,7 @@ class BaseBuilder {
 		*/
 		this._queries = [];
 
+		this._funcs = [];
 		this._sorts = [];
 		this._aggs = {};
 	}
@@ -117,6 +118,22 @@ class BaseBuilder {
 	}
 
 	/**
+	* @description Add functions for function_score queries
+	* @param {string|Object} field - Field/type for sorting
+	* @param {string|Object} value - Value of the Field/Type
+	* @return {BaseBuilder} this
+	*/
+	func (field, value) {
+		// If field is an object, push the whole function object in, else, make it an object
+		const func = typeof field === 'string'
+			? { [field]: value }
+			: field;
+
+		this._funcs.push(func);
+		return this;
+	}
+
+	/**
 	* @description Do we have boolean queries to build
 	* @return {boolean}
 	*/
@@ -141,13 +158,11 @@ class BaseBuilder {
 	}
 
 	/**
-	* @description Build an ES Boolean Query
-	* @return {Object} - ES Query
+	* @description Return our query descriptors
+	* @return {Array<Object>} - Array of query objects
 	*/
-	build () {
-		return this._queries.length
-			? prepareBoolQuery(this._queries)
-			: {};
+	getQueries () {
+		return this._queries;
 	}
 
 	/**
@@ -164,6 +179,24 @@ class BaseBuilder {
 	*/
 	getSorts () {
 		return this._sorts;
+	}
+
+	/**
+	* @description Return our sorting options
+	* @return {Array<Object>} - Array of functions
+	*/
+	getFuncs () {
+		return this._funcs;
+	}
+
+	/**
+	* @description Build an ES Boolean Query
+	* @return {Object} - ES Query
+	*/
+	build () {
+		return this._queries.length
+			? prepareBoolQuery(this._queries)
+			: {};
 	}
 
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,26 +106,57 @@ const prepareBoolQuery = (descriptors) => {
 	};
 };
 
-/**
-* @description Prepare a filtered aggregation query
-* @param {Object} options
-* @param {string} options.name - top-level name for the aggregations
-* @param {Array<Object>} options.aggregations - Array of aggregation objects containing at minimum a field property
-* @param {Array<Object>} options.descriptors - Array of boolean descriptors used to filter our aggs
-*/
-const prepareFilteredAggregation = ({ name = 'all', aggregations, descriptors } = {}) => {
-	invariant(Array.isArray(aggregations) && Array.isArray(descriptors), ERRORS.NOT_AN_ARRAY);
+// /**
+// * @description Prepare a filtered aggregation query
+// * @param {Object} options
+// * @param {string} options.name - top-level name for the aggregations
+// * @param {Array<Object>} options.aggregations - Array of aggregation objects containing at minimum a field property
+// * @param {Array<Object>} options.descriptors - Array of boolean descriptors used to filter our aggs
+// */
+// const prepareFilteredAggregation = ({ name = 'all', aggregations, descriptors } = {}) => {
+// 	invariant(Array.isArray(aggregations) && Array.isArray(descriptors), ERRORS.NOT_AN_ARRAY);
+//
+// 	const aggs = aggregations.reduce((all, aggregate) => {
+// 		// Remove any descriptors if they have the same field as this aggregation
+// 		const boolQueries = descriptors
+// 			.filter(descriptor => descriptor.field !== aggregate.field)
+// 			.reduce(reduceBoolQueries, {});
+//
+// 		// Create our aggregation entry
+// 		all[aggregate.field] = {
+// 			filter: { bool: boolQueries },
+// 			aggs: { [aggregate.field]: { terms: aggregate }}
+// 		};
+//
+// 		return all;
+// 	}, {});
+//
+// 	return {
+// 		[name]: {
+// 			aggs,
+// 			global: {}
+// 		}
+// 	};
+// };
 
-	const aggs = aggregations.reduce((all, aggregate) => {
+/**
+* @description Add filters to our aggregations
+* @param {Array<Object>} aggs - Array of aggregation objects containing at minimum a field property
+* @param {Array<Object>} descriptors - Array of boolean descriptors used to filter our aggs
+* @param {string} name - top-level name for the aggregations
+*/
+const prepareFilteredAggregation = (aggs, descriptors, name = 'all') => {
+	invariant(Array.isArray(descriptors), ERRORS.NOT_AN_ARRAY);
+	// This function is modifying already built aggregations
+	const filtered = Object.getOwnPropertyNames(aggs).reduce((all, agg_name) => {
 		// Remove any descriptors if they have the same field as this aggregation
-		const boolQueries = descriptors
-			.filter(descriptor => descriptor.field !== aggregate.field)
+		const bool = descriptors
+			.filter(descriptor => descriptor.field !== agg_name)
 			.reduce(reduceBoolQueries, {});
 
-		// Create our aggregation entry
-		all[aggregate.field] = {
-			filter: { bool: boolQueries },
-			aggs: { [aggregate.field]: { terms: aggregate }}
+		all[agg_name] = {
+			filter: { bool },
+			aggs: { [agg_name]: aggs[agg_name] }
 		};
 
 		return all;
@@ -133,7 +164,7 @@ const prepareFilteredAggregation = ({ name = 'all', aggregations, descriptors } 
 
 	return {
 		[name]: {
-			aggs,
+			aggs: filtered,
 			global: {}
 		}
 	};
@@ -149,7 +180,7 @@ const saveAggs = (...params) => {
 	if (typeof last(args) === 'function') {
 		const func = args.pop();
 		const results = func(new Builder());
-		nested.aggs = results.buildAggs();
+		nested.aggs = results.getAggs();
 	}
 
 	// Parse out remaining values and store them for later
@@ -198,5 +229,6 @@ module.exports = {
 	prepareBoolQuery,
 	applyRawParameter,
 	reduceBoolQueries,
+	// buildFilteredAggregations,
 	prepareFilteredAggregation
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,44 +106,12 @@ const prepareBoolQuery = (descriptors) => {
 	};
 };
 
-// /**
-// * @description Prepare a filtered aggregation query
-// * @param {Object} options
-// * @param {string} options.name - top-level name for the aggregations
-// * @param {Array<Object>} options.aggregations - Array of aggregation objects containing at minimum a field property
-// * @param {Array<Object>} options.descriptors - Array of boolean descriptors used to filter our aggs
-// */
-// const prepareFilteredAggregation = ({ name = 'all', aggregations, descriptors } = {}) => {
-// 	invariant(Array.isArray(aggregations) && Array.isArray(descriptors), ERRORS.NOT_AN_ARRAY);
-//
-// 	const aggs = aggregations.reduce((all, aggregate) => {
-// 		// Remove any descriptors if they have the same field as this aggregation
-// 		const boolQueries = descriptors
-// 			.filter(descriptor => descriptor.field !== aggregate.field)
-// 			.reduce(reduceBoolQueries, {});
-//
-// 		// Create our aggregation entry
-// 		all[aggregate.field] = {
-// 			filter: { bool: boolQueries },
-// 			aggs: { [aggregate.field]: { terms: aggregate }}
-// 		};
-//
-// 		return all;
-// 	}, {});
-//
-// 	return {
-// 		[name]: {
-// 			aggs,
-// 			global: {}
-// 		}
-// 	};
-// };
-
 /**
 * @description Add filters to our aggregations
 * @param {Array<Object>} aggs - Array of aggregation objects containing at minimum a field property
 * @param {Array<Object>} descriptors - Array of boolean descriptors used to filter our aggs
 * @param {string} name - top-level name for the aggregations
+* @return {Object} Aggregations with filters applied
 */
 const prepareFilteredAggregation = (aggs, descriptors, name = 'all') => {
 	invariant(Array.isArray(descriptors), ERRORS.NOT_AN_ARRAY);
@@ -229,6 +197,5 @@ module.exports = {
 	prepareBoolQuery,
 	applyRawParameter,
 	reduceBoolQueries,
-	// buildFilteredAggregations,
 	prepareFilteredAggregation
 };


### PR DESCRIPTION
This addresses both outstanding issues: #5 and #4.

#4 was already supported but I added a test that shows how to setup function score queries, with a dis_max query, functions, and other function_score settings.

#5 Added a new sort method that basically constructs an object from the two arguments. Added docs, examples, and test cases to show how this can be used.

Other additions (Each change updated relevant tests and documentation):

* Removed `buildAggregation` method since this was not really necessary. It also meant the same logic was applied to two build functions because they needed queries. You can now do this by simply calling `build` and having used the `aggs` method to add aggregations.
* Removed `filteredAggs` from the BaseBuilder.  This was storing aggs in a different manner than the aggs method and would have only caused confusion down the road. To add filters to aggregations, just use the `aggs` method like normal. When you call build, add a filterAggs property to it and set it to true.

```javascript
const query = new QueryBuilder()
  .query('match', 'city', 'South Park')
  .aggs('terms', 'schools')
  .build({ filterAggs: true });
```
