### PR TITLE
Feature/optimization

### DIFF
--- a/__tests__/QueryBuilder.test.js
+++ b/__tests__/QueryBuilder.test.js
@@ -100,9 +100,31 @@ describe('QueryBuilder', () => {
 				query: {
 					bool: {
 						boost: 1.2,
+						must: [
+							{ match: { name: 'Kenny' }},
+							{ match: { alias: 'Mysterion' }}
+						]
+					}
+				}
+			});
+		});
+
+		test('should place should filters inside a filter query', () => {
+			const query = new QueryBuilder()
+				.raw('query.bool.boost', 1.2)
+				.should('match', 'name', 'Kenny')
+				.should('match', 'alias', 'Mysterion')
+				.build();
+
+			expect(query).toEqual({
+				from: 0,
+				size: 15,
+				query: {
+					bool: {
+						boost: 1.2,
 						filter: {
 							bool: {
-								must: [
+								should: [
 									{ match: { name: 'Kenny' }},
 									{ match: { alias: 'Mysterion' }}
 								]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/elastic-querybuilder",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A query builder for Elasticsearch.",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/elastic-querybuilder.git",

--- a/src/BaseBuilder.js
+++ b/src/BaseBuilder.js
@@ -158,12 +158,11 @@ class BaseBuilder {
 	}
 
 	/**
-	* @description Do we have a boolean query that should be filtered
+	* @description Do we have a should query that should be filtered
 	* @return {boolean}
 	*/
-	isBoolean () {
-		const query = prepareBoolQuery(this._queries);
-		return !!(query.bool && Object.getOwnPropertyNames(query.bool).length);
+	hasShould () {
+		return this._queries.some((query) => query.type === BOOL.SHOULD);
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class QueryBuilder extends BaseBuilder {
 	* @return An elasticsearch query
 	*/
 	build (options = {}) {
-		const path = this.isBoolean() ? 'query.bool.filter' : 'query';
+		const path = this.hasShould() ? 'query.bool.filter' : 'query';
 		applyRawParameter(this._query, path, super.build());
 		// Add filtered aggregations if we have any
 		if (this.hasAggs() && options.filterAggs) {

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,9 @@ class QueryBuilder extends BaseBuilder {
 	* @return An elasticsearch query
 	*/
 	build (options = {}) {
+		// If should is combined with any other boolean query, it will only affect the score
+		// and the query will only match the other bool options.  See the 'should' section
+		// here: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
 		const path = this.hasShould() ? 'query.bool.filter' : 'query';
 		applyRawParameter(this._query, path, super.build());
 		// Add filtered aggregations if we have any

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class QueryBuilder extends BaseBuilder {
 
 		// finally add any raw parameter that may exist
 		this._raw.forEach((param) => applyRawParameter(this._query, param.path, param.value));
-		return this._query;
+		return Object.assign({}, this._query);
 	}
 
 	/**
@@ -115,7 +115,7 @@ class QueryBuilder extends BaseBuilder {
 
 		// finally add any raw parameter that may exist
 		this._raw.forEach((param) => applyRawParameter(this._query, param.path, param.value));
-		return this._query;
+		return Object.assign({}, this._query);
 	}
 
 	/**
@@ -150,7 +150,7 @@ class QueryBuilder extends BaseBuilder {
 		}
 		// finally add any raw parameter that may exist
 		this._raw.forEach((param) => applyRawParameter(this._query, param.path, param.value));
-		return this._query;
+		return Object.assign({}, this._query);
 	}
 
 	/**
@@ -179,7 +179,7 @@ class QueryBuilder extends BaseBuilder {
 		}
 		// Add any raw parameters
 		this._raw.forEach((param) => applyRawParameter(this._query, param.path, param.value));
-		return this._query;
+		return Object.assign({}, this._query);
 	}
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class QueryBuilder extends BaseBuilder {
 	* @return {BooleanQueryBuilder} this
 	*/
 	raw (path, value) {
-		invariant(path && value && arguments.length === 2, ERRORS.RAW);
+		invariant(path && value !== undefined && arguments.length === 2, ERRORS.RAW);
 		this._raw.push({ path, value });
 		return this;
 	}


### PR DESCRIPTION
Only nest boolean queries in a filter if a should is present.
`raw` method now checks for undefined in param validation. So you can set things like `.raw('min_score', 0)`.
Updated Package number
Build's now use Object.assign, so you can call build multiple times and modify the results without affecting future calls to build