### PR TITLE
Feature/add track scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ builder.from(from: number): QueryBuilder
 builder.size(size: number): QueryBuilder
 ```
 
+##### `trackScores`
+> Sets the track_scores option.
+
+```javascript
+builder.trackScores(trackScores: boolean): QueryBuilder
+```
+
 ##### `raw`
 > Allows to set a value on the query object at your path.
 

--- a/__tests__/QueryBuilder.test.js
+++ b/__tests__/QueryBuilder.test.js
@@ -52,6 +52,18 @@ describe('QueryBuilder', () => {
 		expect(builder._query.size).toEqual(newSize);
 	});
 
+	test('should be able set the track_score settings', () => {
+		const builder = new QueryBuilder();
+		const trackScores = true;
+		// Set the stractScore
+		builder.trackScores(trackScores);
+		expect(builder._query.track_scores).toEqual(trackScores);
+		// Update them without a value and make sure they do not get set to undefined
+		builder.trackScores();
+		expect(builder._query.track_scores).toEqual(trackScores);
+	});
+
+
 	describe('build', () => {
 
 		test('should allow me to add raw parameters to the final query', () => {
@@ -81,6 +93,22 @@ describe('QueryBuilder', () => {
 			expect(query).toEqual({
 				from: 0,
 				size: 15,
+				query: {
+					match_none: {}
+				}
+			});
+		});
+
+		test('should handle building query with track_scores', () => {
+			const query = new QueryBuilder()
+				.trackScores(true)
+				.query('match_none')
+				.build();
+
+			expect(query).toEqual({
+				from: 0,
+				size: 15,
+				track_scores: true,
 				query: {
 					match_none: {}
 				}

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,16 @@ class QueryBuilder extends BaseBuilder {
 	}
 
 	/**
+	* @description Sets the track scores
+	* @param {number} trackScores - Boolean value for tracking score
+	* @return {QueryBuilder} this
+	*/
+	trackScores (trackScores) {
+		if (trackScores !== undefined) { this._query.track_scores = trackScores; }
+		return this;
+	}
+
+	/**
 	* @description Add a raw parameter to any part of your query
 	* @param {string} path - The path to add the value at
 	* @param {*} value - Value to add at the path


### PR DESCRIPTION
Added option to allow setting the track scores option.  If you are using custom sorting, you need to set track_scores to retain the max_score.

Fo reference on sorting, please refer to the API.
https://www.elastic.co/guide/en/elasticsearch/guide/current/_sorting.html

> The second is that the _score and max_score are both null. Calculating the _score can be quite expensive, and usually its only purpose is for sorting; we’re not sorting by relevance, so it doesn’t make sense to keep track of the _score. If you want the _score to be calculated regardless, you can set the track_scores parameter to true.