### PR TITLE
Feature/fieldless aggs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/elastic-querybuilder",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "A query builder for Elasticsearch.",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/elastic-querybuilder.git",

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ const last = (collection) => {
 	return collection.length ? collection[collection.length - 1] : undefined;
 };
 
-const getAggName = (type, field) => {
+const getAggName = (type, field = {}) => {
 	return typeof field !== 'string'
 		? field.path || field.field || `agg_${type}`
 		: field;


### PR DESCRIPTION
This allows for creating reverse nested aggs like so:

```javascript
let builder = new QueryBuilder();

builder.aggs('nested', { path: 'specialties' }, agg_builder => {
	return agg_builder.aggs('terms', 'specialties.specialty.untouched', { size: 7000 }, reverse_builder => {
		return reverse_builder.aggs('reverse_nested');
	});
});

builder.build();
```

generates the following query

```javascript
{
  "from": 0,
  "size": 15,
  "query": {
    "match_all": {}
  },
  "aggs": {
    "specialties": {
      "nested": {
        "path": "specialties"
      },
      "aggs": {
        "specialties.specialty.untouched": {
          "terms": {
            "field": "specialties.specialty.untouched",
            "size": 7000
          },
          "aggs": {
            "agg_reverse_nested": {
              "reverse_nested": {}
            }
          }
        }
      }
    }
  }
}
```